### PR TITLE
Tidy up and fix for function_exists failure

### DIFF
--- a/mailgun.php
+++ b/mailgun.php
@@ -140,202 +140,204 @@ Class PBC_WP_Mail_MailGun{
 }
 
 // Only let this get created once
-function wp_mail( $to, $subject, $message, $headers = "", $attachments = "" ){
+if ( !function_exists('wp_mail') ) {
+	function wp_mail( $to, $subject, $message, $headers = "", $attachments = "" ){
 
-	global $mg;
+		global $mg;
 
-	// look for the MailGun wrapper, if it doesn't exist create it
-	if(!isset($mg)){
-		$mg = new PBC_WP_Mail_MailGun();
-	}
+		// look for the MailGun wrapper, if it doesn't exist create it
+		if(!isset($mg)){
+			$mg = new PBC_WP_Mail_MailGun();
+		}
 
-	$atts = apply_filters( 'wp_mail', compact( 'to', 'subject', 'message', 'headers', 'attachments' ) );
+		$atts = apply_filters( 'wp_mail', compact( 'to', 'subject', 'message', 'headers', 'attachments' ) );
 
-	if ( isset( $atts['to'] ) ) {
-		$to = $atts['to'];
-	}
+		if ( isset( $atts['to'] ) ) {
+			$to = $atts['to'];
+		}
 
-	if ( isset( $atts['subject'] ) ) {
-		$subject = $atts['subject'];
-	}
+		if ( isset( $atts['subject'] ) ) {
+			$subject = $atts['subject'];
+		}
 
-	if ( isset( $atts['message'] ) ) {
-		$message = $atts['message'];
-	}
+		if ( isset( $atts['message'] ) ) {
+			$message = $atts['message'];
+		}
 
-	if ( isset( $atts['headers'] ) ) {
-		$headers = $atts['headers'];
-	}
+		if ( isset( $atts['headers'] ) ) {
+			$headers = $atts['headers'];
+		}
 
-	if ( isset( $atts['attachments'] ) ) {
-		$attachments = $atts['attachments'];
-	}
+		if ( isset( $atts['attachments'] ) ) {
+			$attachments = $atts['attachments'];
+		}
 
-	if ( ! is_array( $attachments ) ) {
-		$attachments = explode( "\n", str_replace( "\r\n", "\n", $attachments ) );
-	}
+		if ( ! is_array( $attachments ) ) {
+			$attachments = explode( "\n", str_replace( "\r\n", "\n", $attachments ) );
+		}
 
 
 
-	// Headers
-	$cc = $bcc = $reply_to = array();
+		// Headers
+		$cc = $bcc = $reply_to = array();
 
-	if ( empty( $headers ) ) {
-		$headers = array();
-	} else {
-		if ( !is_array( $headers ) ) {
-			// Explode the headers out, so this function can take both
-			// string headers and an array of headers.
-			$tempheaders = explode( "\n", str_replace( "\r\n", "\n", $headers ) );
+		if ( empty( $headers ) ) {
+			$headers = array();
 		} else {
-			$tempheaders = $headers;
-		}
-		$headers = array();
+			if ( !is_array( $headers ) ) {
+				// Explode the headers out, so this function can take both
+				// string headers and an array of headers.
+				$tempheaders = explode( "\n", str_replace( "\r\n", "\n", $headers ) );
+			} else {
+				$tempheaders = $headers;
+			}
+			$headers = array();
 
-		// If it's actually got contents
-		if ( !empty( $tempheaders ) ) {
-			// Iterate through the raw headers
-			foreach ( (array) $tempheaders as $header ) {
-				if ( strpos($header, ':') === false ) {
-					if ( false !== stripos( $header, 'boundary=' ) ) {
-						$parts = preg_split('/boundary=/i', trim( $header ) );
-						$boundary = trim( str_replace( array( "'", '"' ), '', $parts[1] ) );
+			// If it's actually got contents
+			if ( !empty( $tempheaders ) ) {
+				// Iterate through the raw headers
+				foreach ( (array) $tempheaders as $header ) {
+					if ( strpos($header, ':') === false ) {
+						if ( false !== stripos( $header, 'boundary=' ) ) {
+							$parts = preg_split('/boundary=/i', trim( $header ) );
+							$boundary = trim( str_replace( array( "'", '"' ), '', $parts[1] ) );
+						}
+						continue;
 					}
-					continue;
-				}
-				// Explode them out
-				list( $name, $content ) = explode( ':', trim( $header ), 2 );
+					// Explode them out
+					list( $name, $content ) = explode( ':', trim( $header ), 2 );
 
-				// Cleanup crew
-				$name    = trim( $name    );
-				$content = trim( $content );
+					// Cleanup crew
+					$name    = trim( $name    );
+					$content = trim( $content );
 
-				switch ( strtolower( $name ) ) {
-					// Mainly for legacy -- process a From: header if it's there
-					case 'from':
-						$bracket_pos = strpos( $content, '<' );
-						if ( $bracket_pos !== false ) {
-							// Text before the bracketed email is the "From" name.
-							if ( $bracket_pos > 0 ) {
-								$from_name = substr( $content, 0, $bracket_pos - 1 );
-								$from_name = str_replace( '"', '', $from_name );
-								$from_name = trim( $from_name );
+					switch ( strtolower( $name ) ) {
+						// Mainly for legacy -- process a From: header if it's there
+						case 'from':
+							$bracket_pos = strpos( $content, '<' );
+							if ( $bracket_pos !== false ) {
+								// Text before the bracketed email is the "From" name.
+								if ( $bracket_pos > 0 ) {
+									$from_name = substr( $content, 0, $bracket_pos - 1 );
+									$from_name = str_replace( '"', '', $from_name );
+									$from_name = trim( $from_name );
+								}
+
+								$from_email = substr( $content, $bracket_pos + 1 );
+								$from_email = str_replace( '>', '', $from_email );
+								$from_email = trim( $from_email );
+
+							// Avoid setting an empty $from_email.
+							} elseif ( '' !== trim( $content ) ) {
+								$from_email = trim( $content );
 							}
+							break;
+						case 'content-type':
+							if ( strpos( $content, ';' ) !== false ) {
+								list( $type, $charset_content ) = explode( ';', $content );
+								$content_type = trim( $type );
+								if ( false !== stripos( $charset_content, 'charset=' ) ) {
+									$charset = trim( str_replace( array( 'charset=', '"' ), '', $charset_content ) );
+								} elseif ( false !== stripos( $charset_content, 'boundary=' ) ) {
+									$boundary = trim( str_replace( array( 'BOUNDARY=', 'boundary=', '"' ), '', $charset_content ) );
+									$charset = '';
+								}
 
-							$from_email = substr( $content, $bracket_pos + 1 );
-							$from_email = str_replace( '>', '', $from_email );
-							$from_email = trim( $from_email );
-
-						// Avoid setting an empty $from_email.
-						} elseif ( '' !== trim( $content ) ) {
-							$from_email = trim( $content );
-						}
-						break;
-					case 'content-type':
-						if ( strpos( $content, ';' ) !== false ) {
-							list( $type, $charset_content ) = explode( ';', $content );
-							$content_type = trim( $type );
-							if ( false !== stripos( $charset_content, 'charset=' ) ) {
-								$charset = trim( str_replace( array( 'charset=', '"' ), '', $charset_content ) );
-							} elseif ( false !== stripos( $charset_content, 'boundary=' ) ) {
-								$boundary = trim( str_replace( array( 'BOUNDARY=', 'boundary=', '"' ), '', $charset_content ) );
-								$charset = '';
+							// Avoid setting an empty $content_type.
+							} elseif ( '' !== trim( $content ) ) {
+								$content_type = trim( $content );
 							}
-
-						// Avoid setting an empty $content_type.
-						} elseif ( '' !== trim( $content ) ) {
-							$content_type = trim( $content );
-						}
-						break;
-					case 'cc':
-						$cc = array_merge( (array) $cc, explode( ',', $content ) );
-						break;
-					case 'bcc':
-						$bcc = array_merge( (array) $bcc, explode( ',', $content ) );
-						break;
-					case 'reply-to':
-						$reply_to = array_merge( (array) $reply_to, explode( ',', $content ) );
-						break;
-					default:
-						// Add it to our grand headers array
-						$headers[trim( $name )] = trim( $content );
-						break;
+							break;
+						case 'cc':
+							$cc = array_merge( (array) $cc, explode( ',', $content ) );
+							break;
+						case 'bcc':
+							$bcc = array_merge( (array) $bcc, explode( ',', $content ) );
+							break;
+						case 'reply-to':
+							$reply_to = array_merge( (array) $reply_to, explode( ',', $content ) );
+							break;
+						default:
+							// Add it to our grand headers array
+							$headers[trim( $name )] = trim( $content );
+							break;
+					}
 				}
 			}
 		}
-	}
 
 
 
-	 /* If we don't have an email from the input headers default to wordpress@$sitename
-	 * Some hosts will block outgoing mail from this address if it doesn't exist but
-	 * there's no easy alternative. Defaulting to admin_email might appear to be another
-	 * option but some hosts may refuse to relay mail from an unknown domain. See
-	 * https://core.trac.wordpress.org/ticket/5007.
-	 */
-
-	if ( !isset( $from_email ) ) {
-		// Get the site domain and get rid of www.
-		$sitename = strtolower( $_SERVER['SERVER_NAME'] );
-		if ( substr( $sitename, 0, 4 ) == 'www.' ) {
-			$sitename = substr( $sitename, 4 );
-		}
-		$from_email = 'wordpress@' . $sitename;
-	}
-
-	// Can filter that
-	$from_email = apply_filters( 'wp_mail_from', $from_email );
-
-	// From email and name
-	// If we don't have a name from the input headers
-	if ( !isset( $from_name ) ) {
-		$from_name = 'WordPress';
-	}
-	$from_name = apply_filters( 'wp_mail_from_name', $from_name );
-
-	// this will be passed into send
-	$from = [
-		"address" =>$from_email,
-		"name" => $from_name
-	];
-
-	if ( !is_array( $to ) ) {
-		 $to = explode( ',', $to );
-	}
-
-	$to_addresses = [];
-
-	foreach ( (array) $to as $recipient ) {
-		// Break $recipient into name and address parts if in the format "Foo <bar@baz.com>"
-		$recipient_name = '';
-		if ( preg_match( '/(.*)<(.+)>/', $recipient, $matches ) ) {
-			if ( count( $matches ) == 3 ) {
-				$recipient_name = $matches[1];
-				$recipient = $matches[2];
-			}
-		}
-
-		$to_addresses[$recipient] = $recipient_name;
-	}
-
-
-	try {
-		$resp = $mg->send($from, $to_addresses, $subject, $message, $headers, $attachments);
-	} catch (Exception $e){
-		$mail_error_data = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
-
-		/**
-		 * Fires after a phpmailerException is caught.
-		 *
-		 * @since 4.4.0
-		 *
-		 * @param WP_Error $error A WP_Error object with the phpmailerException code, message, and an array
-		 *                        containing the mail recipient, subject, message, headers, and attachments.
+		 /* If we don't have an email from the input headers default to wordpress@$sitename
+		 * Some hosts will block outgoing mail from this address if it doesn't exist but
+		 * there's no easy alternative. Defaulting to admin_email might appear to be another
+		 * option but some hosts may refuse to relay mail from an unknown domain. See
+		 * https://core.trac.wordpress.org/ticket/5007.
 		 */
-		do_action( 'wp_mail_failed', new WP_Error( $e->getCode(), $e->getMessage(), $mail_error_data ) );
 
-		return false;
+		if ( !isset( $from_email ) ) {
+			// Get the site domain and get rid of www.
+			$sitename = strtolower( $_SERVER['SERVER_NAME'] );
+			if ( substr( $sitename, 0, 4 ) == 'www.' ) {
+				$sitename = substr( $sitename, 4 );
+			}
+			$from_email = 'wordpress@' . $sitename;
+		}
+
+		// Can filter that
+		$from_email = apply_filters( 'wp_mail_from', $from_email );
+
+		// From email and name
+		// If we don't have a name from the input headers
+		if ( !isset( $from_name ) ) {
+			$from_name = 'WordPress';
+		}
+		$from_name = apply_filters( 'wp_mail_from_name', $from_name );
+
+		// this will be passed into send
+		$from = [
+			"address" =>$from_email,
+			"name" => $from_name
+		];
+
+		if ( !is_array( $to ) ) {
+			 $to = explode( ',', $to );
+		}
+
+		$to_addresses = [];
+
+		foreach ( (array) $to as $recipient ) {
+			// Break $recipient into name and address parts if in the format "Foo <bar@baz.com>"
+			$recipient_name = '';
+			if ( preg_match( '/(.*)<(.+)>/', $recipient, $matches ) ) {
+				if ( count( $matches ) == 3 ) {
+					$recipient_name = $matches[1];
+					$recipient = $matches[2];
+				}
+			}
+
+			$to_addresses[$recipient] = $recipient_name;
+		}
+
+
+		try {
+			$resp = $mg->send($from, $to_addresses, $subject, $message, $headers, $attachments);
+		} catch (Exception $e){
+			$mail_error_data = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
+
+			/**
+			 * Fires after a phpmailerException is caught.
+			 *
+			 * @since 4.4.0
+			 *
+			 * @param WP_Error $error A WP_Error object with the phpmailerException code, message, and an array
+			 *                        containing the mail recipient, subject, message, headers, and attachments.
+			 */
+			do_action( 'wp_mail_failed', new WP_Error( $e->getCode(), $e->getMessage(), $mail_error_data ) );
+
+			return false;
+		}
+
+		return true;
 	}
-
-	return true;
 }

--- a/mailgun.php
+++ b/mailgun.php
@@ -1,13 +1,13 @@
 <?php
 /**
-     * Plugin Name: MailGunWPMail
-     * Plugin URI: http://poweredbycoffee.co.uk
-     * Description: Enables the loading of plugins sitting in mu-plugins (as folders)
-     * Version: 0.1
-     * Author: poweredbycoffee, stewarty
-     * Author URI: http://poweredbycoffee.co.uk
-     *
-     */
+	 * Plugin Name: MailGunWPMail
+	 * Plugin URI: http://poweredbycoffee.co.uk
+	 * Description: Enables the loading of plugins sitting in mu-plugins (as folders)
+	 * Version: 0.1
+	 * Author: poweredbycoffee, stewarty
+	 * Author URI: http://poweredbycoffee.co.uk
+	 *
+	 */
 
 
 include('vendor/autoload.php');
@@ -17,17 +17,17 @@ Class PBC_WP_Mail_MailGun{
 
 	var $http;
 	var $mg;
-	
+
 	public function __construct(){
 		$this->http = new \Http\Adapter\Guzzle6\Client();
 		$this->mg = new \Mailgun\Mailgun(MAILGUN_API_KEY, $this->http);
 	}
 
 	public function send($from, $to, $subject, $message){
-		
+
 
 		$builder = $this->mg->MessageBuilder();
-		
+
 
 		$builder->setFromAddress($from['address']);
 
@@ -39,320 +39,303 @@ Class PBC_WP_Mail_MailGun{
 		$builder->setTextBody($message);
 		$builder->setSubject($subject);
 
-		
+
 		//pbc_dump($builder);
 
 		if ( empty( $headers ) ) {
-        	$headers = array();
-    	} else {
+			$headers = array();
+		} else {
 
-        	if ( !is_array( $headers ) ) {
-           	 	// Explode the headers out, so this function can take both
-            	// string headers and an array of headers.
-           		 $tempheaders = explode( "\n", str_replace( "\r\n", "\n", $headers ) );
-        	} else {
-            	$tempheaders = $headers;
-        	
-       		}
+			if ( !is_array( $headers ) ) {
+					// Explode the headers out, so this function can take both
+					// string headers and an array of headers.
+					 $tempheaders = explode( "\n", str_replace( "\r\n", "\n", $headers ) );
+			} else {
+					$tempheaders = $headers;
 
-	      //  pbc_dump($builder);
-	       // die("what?");
+			}
 
-	        $headers = array();
-	        $cc = array();
-	        $bcc = array();
- 
-	        // If it's actually got contents
-	        if ( !empty( $tempheaders ) ) {
-	            // Iterate through the raw headers
-	            foreach ( (array) $tempheaders as $header ) {
-	                if ( strpos($header, ':') === false ) {
-	                    if ( false !== stripos( $header, 'boundary=' ) ) {
-	                        $parts = preg_split('/boundary=/i', trim( $header ) );
-	                        $boundary = trim( str_replace( array( "'", '"' ), '', $parts[1] ) );
-	                    }
-	                    continue;
-	                }
-	                // Explode them out
-	                list( $name, $content ) = explode( ':', trim( $header ), 2 );
-	 
-	                // Cleanup crew
-	                $name    = trim( $name    );
-	                $content = trim( $content );
-	 
-	                switch ( strtolower( $name ) ) {
-	                    // Mainly for legacy -- process a From: header if it's there
-	                    case 'from':
-	                        $bracket_pos = strpos( $content, '<' );
-	                        if ( $bracket_pos !== false ) {
-	                            // Text before the bracketed email is the "From" name.
-	                            if ( $bracket_pos > 0 ) {
-	                                $from_name = substr( $content, 0, $bracket_pos - 1 );
-	                                $from_name = str_replace( '"', '', $from_name );
-	                                $from_name = trim( $from_name );
-	                            }
-	 
-	                            $from_email = substr( $content, $bracket_pos + 1 );
-	                            $from_email = str_replace( '>', '', $from_email );
-	                            $from_email = trim( $from_email );
-	 
-	                        // Avoid setting an empty $from_email.
-	                        } elseif ( '' !== trim( $content ) ) {
-	                            $from_email = trim( $content );
-	                        }
-	                        break;
-	                    case 'cc':
-	                        $cc = array_merge( (array) $cc, explode( ',', $content ) );
-	                        break;
-	                    case 'bcc':
-	                        $bcc = array_merge( (array) $bcc, explode( ',', $content ) );
-	                        break;
-	                    default:
-	                        // Add it to our grand headers array
-	                        $headers[trim( $name )] = trim( $content );
-	                        break;
-	                }
-	            }
-	        }
+				//  pbc_dump($builder);
+				 // die("what?");
 
-	        foreach ($cc as $email){
-	        	$builder->addCcRecipient($email);
-	        }
+			$headers = array();
+			$cc = array();
+			$bcc = array();
 
-	        foreach ($bcc as $email){
-	        	$builder->addCcRecipient($email);
-	        }
+			// If it's actually got contents
+			if ( !empty( $tempheaders ) ) {
+					// Iterate through the raw headers
+					foreach ( (array) $tempheaders as $header ) {
+							if ( strpos($header, ':') === false ) {
+									if ( false !== stripos( $header, 'boundary=' ) ) {
+											$parts = preg_split('/boundary=/i', trim( $header ) );
+											$boundary = trim( str_replace( array( "'", '"' ), '', $parts[1] ) );
+									}
+									continue;
+							}
+							// Explode them out
+							list( $name, $content ) = explode( ':', trim( $header ), 2 );
 
-	        foreach ($headers as $name => $data){
-	        	$builder->addCustomHeader($name, $data);
-	        }
+							// Cleanup crew
+							$name    = trim( $name    );
+							$content = trim( $content );
+
+							switch ( strtolower( $name ) ) {
+									// Mainly for legacy -- process a From: header if it's there
+									case 'from':
+											$bracket_pos = strpos( $content, '<' );
+											if ( $bracket_pos !== false ) {
+													// Text before the bracketed email is the "From" name.
+													if ( $bracket_pos > 0 ) {
+															$from_name = substr( $content, 0, $bracket_pos - 1 );
+															$from_name = str_replace( '"', '', $from_name );
+															$from_name = trim( $from_name );
+													}
+
+													$from_email = substr( $content, $bracket_pos + 1 );
+													$from_email = str_replace( '>', '', $from_email );
+													$from_email = trim( $from_email );
+
+											// Avoid setting an empty $from_email.
+											} elseif ( '' !== trim( $content ) ) {
+													$from_email = trim( $content );
+											}
+											break;
+									case 'cc':
+											$cc = array_merge( (array) $cc, explode( ',', $content ) );
+											break;
+									case 'bcc':
+											$bcc = array_merge( (array) $bcc, explode( ',', $content ) );
+											break;
+									default:
+											// Add it to our grand headers array
+											$headers[trim( $name )] = trim( $content );
+											break;
+							}
+					}
+			}
+
+			foreach ($cc as $email){
+				$builder->addCcRecipient($email);
+			}
+
+			foreach ($bcc as $email){
+				$builder->addCcRecipient($email);
+			}
+
+			foreach ($headers as $name => $data){
+				$builder->addCustomHeader($name, $data);
+			}
 
 		}
-
-		// echo "hello";
-		// pbc_dump($builder->getMessage());        
-		// die("what?");
 
 		try{
-	    	$this->mg->post( MAILGUN_DOMAIN . "/messages", $builder->getMessage());
-	    } catch(exception $e){
-	    	
-	    }
+				$this->mg->post( MAILGUN_DOMAIN . "/messages", $builder->getMessage());
+			} catch(exception $e){
 
-	   // die();
-    }
+			}
+
+		 // die();
+		}
 }
 
-
 // Only let this get created once
+function wp_mail( $to, $subject, $message, $headers = "", $attachments = "" ){
+
+	global $mg;
+
+	// look for the MailGun wrapper, if it doesn't exist create it
+	if(!isset($mg)){
+		$mg = new PBC_WP_Mail_MailGun();
+	}
+
+	$atts = apply_filters( 'wp_mail', compact( 'to', 'subject', 'message', 'headers', 'attachments' ) );
+
+	if ( isset( $atts['to'] ) ) {
+		$to = $atts['to'];
+	}
+
+	if ( isset( $atts['subject'] ) ) {
+		$subject = $atts['subject'];
+	}
+
+	if ( isset( $atts['message'] ) ) {
+		$message = $atts['message'];
+	}
+
+	if ( isset( $atts['headers'] ) ) {
+		$headers = $atts['headers'];
+	}
+
+	if ( isset( $atts['attachments'] ) ) {
+		$attachments = $atts['attachments'];
+	}
+
+	if ( ! is_array( $attachments ) ) {
+		$attachments = explode( "\n", str_replace( "\r\n", "\n", $attachments ) );
+	}
 
 
 
+	// Headers
+	$cc = $bcc = $reply_to = array();
 
-	function wp_mail( $to, $subject, $message, $headers = "", $attachments = "" ){
-		
-		global $mg;
+	if ( empty( $headers ) ) {
+		$headers = array();
+	} else {
+		if ( !is_array( $headers ) ) {
+			// Explode the headers out, so this function can take both
+			// string headers and an array of headers.
+			$tempheaders = explode( "\n", str_replace( "\r\n", "\n", $headers ) );
+		} else {
+			$tempheaders = $headers;
+		}
+		$headers = array();
 
-		// look for the MailGun wrapper, if it doesn't exist create it
-		if(!isset($mg)){
-			$mg = new PBC_WP_Mail_MailGun();
+		// If it's actually got contents
+		if ( !empty( $tempheaders ) ) {
+			// Iterate through the raw headers
+			foreach ( (array) $tempheaders as $header ) {
+				if ( strpos($header, ':') === false ) {
+					if ( false !== stripos( $header, 'boundary=' ) ) {
+						$parts = preg_split('/boundary=/i', trim( $header ) );
+						$boundary = trim( str_replace( array( "'", '"' ), '', $parts[1] ) );
+					}
+					continue;
+				}
+				// Explode them out
+				list( $name, $content ) = explode( ':', trim( $header ), 2 );
+
+				// Cleanup crew
+				$name    = trim( $name    );
+				$content = trim( $content );
+
+				switch ( strtolower( $name ) ) {
+					// Mainly for legacy -- process a From: header if it's there
+					case 'from':
+						$bracket_pos = strpos( $content, '<' );
+						if ( $bracket_pos !== false ) {
+							// Text before the bracketed email is the "From" name.
+							if ( $bracket_pos > 0 ) {
+								$from_name = substr( $content, 0, $bracket_pos - 1 );
+								$from_name = str_replace( '"', '', $from_name );
+								$from_name = trim( $from_name );
+							}
+
+							$from_email = substr( $content, $bracket_pos + 1 );
+							$from_email = str_replace( '>', '', $from_email );
+							$from_email = trim( $from_email );
+
+						// Avoid setting an empty $from_email.
+						} elseif ( '' !== trim( $content ) ) {
+							$from_email = trim( $content );
+						}
+						break;
+					case 'content-type':
+						if ( strpos( $content, ';' ) !== false ) {
+							list( $type, $charset_content ) = explode( ';', $content );
+							$content_type = trim( $type );
+							if ( false !== stripos( $charset_content, 'charset=' ) ) {
+								$charset = trim( str_replace( array( 'charset=', '"' ), '', $charset_content ) );
+							} elseif ( false !== stripos( $charset_content, 'boundary=' ) ) {
+								$boundary = trim( str_replace( array( 'BOUNDARY=', 'boundary=', '"' ), '', $charset_content ) );
+								$charset = '';
+							}
+
+						// Avoid setting an empty $content_type.
+						} elseif ( '' !== trim( $content ) ) {
+							$content_type = trim( $content );
+						}
+						break;
+					case 'cc':
+						$cc = array_merge( (array) $cc, explode( ',', $content ) );
+						break;
+					case 'bcc':
+						$bcc = array_merge( (array) $bcc, explode( ',', $content ) );
+						break;
+					case 'reply-to':
+						$reply_to = array_merge( (array) $reply_to, explode( ',', $content ) );
+						break;
+					default:
+						// Add it to our grand headers array
+						$headers[trim( $name )] = trim( $content );
+						break;
+				}
+			}
+		}
+	}
+
+
+
+	 /* If we don't have an email from the input headers default to wordpress@$sitename
+	 * Some hosts will block outgoing mail from this address if it doesn't exist but
+	 * there's no easy alternative. Defaulting to admin_email might appear to be another
+	 * option but some hosts may refuse to relay mail from an unknown domain. See
+	 * https://core.trac.wordpress.org/ticket/5007.
+	 */
+
+	if ( !isset( $from_email ) ) {
+		// Get the site domain and get rid of www.
+		$sitename = strtolower( $_SERVER['SERVER_NAME'] );
+		if ( substr( $sitename, 0, 4 ) == 'www.' ) {
+			$sitename = substr( $sitename, 4 );
+		}
+		$from_email = 'wordpress@' . $sitename;
+	}
+
+	// Can filter that
+	$from_email = apply_filters( 'wp_mail_from', $from_email );
+
+	// From email and name
+	// If we don't have a name from the input headers
+	if ( !isset( $from_name ) ) {
+		$from_name = 'WordPress';
+	}
+	$from_name = apply_filters( 'wp_mail_from_name', $from_name );
+
+	// this will be passed into send
+	$from = [
+		"address" =>$from_email,
+		"name" => $from_name
+	];
+
+	if ( !is_array( $to ) ) {
+		 $to = explode( ',', $to );
+	}
+
+	$to_addresses = [];
+
+	foreach ( (array) $to as $recipient ) {
+		// Break $recipient into name and address parts if in the format "Foo <bar@baz.com>"
+		$recipient_name = '';
+		if ( preg_match( '/(.*)<(.+)>/', $recipient, $matches ) ) {
+			if ( count( $matches ) == 3 ) {
+				$recipient_name = $matches[1];
+				$recipient = $matches[2];
+			}
 		}
 
-		$atts = apply_filters( 'wp_mail', compact( 'to', 'subject', 'message', 'headers', 'attachments' ) );
- 
-	    if ( isset( $atts['to'] ) ) {
-	        $to = $atts['to'];
-	    }
-	 
-	    if ( isset( $atts['subject'] ) ) {
-	        $subject = $atts['subject'];
-	    }
-	 
-	    if ( isset( $atts['message'] ) ) {
-	        $message = $atts['message'];
-	    }
-	 
-	    if ( isset( $atts['headers'] ) ) {
-	        $headers = $atts['headers'];
-	    }
-	 
-	    if ( isset( $atts['attachments'] ) ) {
-	        $attachments = $atts['attachments'];
-	    }
-	 
-	    if ( ! is_array( $attachments ) ) {
-	        $attachments = explode( "\n", str_replace( "\r\n", "\n", $attachments ) );
-	    }
+		$to_addresses[$recipient] = $recipient_name;
+	}
 
 
-		
-		// Headers
-    $cc = $bcc = $reply_to = array();
- 
-    if ( empty( $headers ) ) {
-        $headers = array();
-    } else {
-        if ( !is_array( $headers ) ) {
-            // Explode the headers out, so this function can take both
-            // string headers and an array of headers.
-            $tempheaders = explode( "\n", str_replace( "\r\n", "\n", $headers ) );
-        } else {
-            $tempheaders = $headers;
-        }
-        $headers = array();
- 
-        // If it's actually got contents
-        if ( !empty( $tempheaders ) ) {
-            // Iterate through the raw headers
-            foreach ( (array) $tempheaders as $header ) {
-                if ( strpos($header, ':') === false ) {
-                    if ( false !== stripos( $header, 'boundary=' ) ) {
-                        $parts = preg_split('/boundary=/i', trim( $header ) );
-                        $boundary = trim( str_replace( array( "'", '"' ), '', $parts[1] ) );
-                    }
-                    continue;
-                }
-                // Explode them out
-                list( $name, $content ) = explode( ':', trim( $header ), 2 );
- 
-                // Cleanup crew
-                $name    = trim( $name    );
-                $content = trim( $content );
- 
-                switch ( strtolower( $name ) ) {
-                    // Mainly for legacy -- process a From: header if it's there
-                    case 'from':
-                        $bracket_pos = strpos( $content, '<' );
-                        if ( $bracket_pos !== false ) {
-                            // Text before the bracketed email is the "From" name.
-                            if ( $bracket_pos > 0 ) {
-                                $from_name = substr( $content, 0, $bracket_pos - 1 );
-                                $from_name = str_replace( '"', '', $from_name );
-                                $from_name = trim( $from_name );
-                            }
- 
-                            $from_email = substr( $content, $bracket_pos + 1 );
-                            $from_email = str_replace( '>', '', $from_email );
-                            $from_email = trim( $from_email );
- 
-                        // Avoid setting an empty $from_email.
-                        } elseif ( '' !== trim( $content ) ) {
-                            $from_email = trim( $content );
-                        }
-                        break;
-                    case 'content-type':
-                        if ( strpos( $content, ';' ) !== false ) {
-                            list( $type, $charset_content ) = explode( ';', $content );
-                            $content_type = trim( $type );
-                            if ( false !== stripos( $charset_content, 'charset=' ) ) {
-                                $charset = trim( str_replace( array( 'charset=', '"' ), '', $charset_content ) );
-                            } elseif ( false !== stripos( $charset_content, 'boundary=' ) ) {
-                                $boundary = trim( str_replace( array( 'BOUNDARY=', 'boundary=', '"' ), '', $charset_content ) );
-                                $charset = '';
-                            }
- 
-                        // Avoid setting an empty $content_type.
-                        } elseif ( '' !== trim( $content ) ) {
-                            $content_type = trim( $content );
-                        }
-                        break;
-                    case 'cc':
-                        $cc = array_merge( (array) $cc, explode( ',', $content ) );
-                        break;
-                    case 'bcc':
-                        $bcc = array_merge( (array) $bcc, explode( ',', $content ) );
-                        break;
-                    case 'reply-to':
-                        $reply_to = array_merge( (array) $reply_to, explode( ',', $content ) );
-                        break;
-                    default:
-                        // Add it to our grand headers array
-                        $headers[trim( $name )] = trim( $content );
-                        break;
-                }
-            }
-        }
-    }
-		
+	try {
+		$resp = $mg->send($from, $to_addresses, $subject, $message, $headers, $attachments);
+	} catch (Exception $e){
+		$mail_error_data = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
 
+		/**
+		 * Fires after a phpmailerException is caught.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param WP_Error $error A WP_Error object with the phpmailerException code, message, and an array
+		 *                        containing the mail recipient, subject, message, headers, and attachments.
+		 */
+		do_action( 'wp_mail_failed', new WP_Error( $e->getCode(), $e->getMessage(), $mail_error_data ) );
 
-	   	 /* If we don't have an email from the input headers default to wordpress@$sitename
-	     * Some hosts will block outgoing mail from this address if it doesn't exist but
-	     * there's no easy alternative. Defaulting to admin_email might appear to be another
-	     * option but some hosts may refuse to relay mail from an unknown domain. See
-	     * https://core.trac.wordpress.org/ticket/5007.
-	     */
-	 
-	    if ( !isset( $from_email ) ) {
-	        // Get the site domain and get rid of www.
-	        $sitename = strtolower( $_SERVER['SERVER_NAME'] );
-	        if ( substr( $sitename, 0, 4 ) == 'www.' ) {
-	            $sitename = substr( $sitename, 4 );
-	        }
-	 
-	        $from_email = 'wordpress@' . $sitename;
-	    }
+		return false;
+	}
 
-	    // Can filter that
-	    $from_email = apply_filters( 'wp_mail_from', $from_email );
- 
- 		// From email and name
-	    // If we don't have a name from the input headers
-	    if ( !isset( $from_name ) )
-	        $from_name = 'WordPress';	 	
-	 	$from_name = apply_filters( 'wp_mail_from_name', $from_name );
-
-
-	 	// this will be passed into send
-	 	$from = [
-	 		"address" =>$from_email,
-	 		"name" => $from_name
-	 	];
-
-	 	if ( !is_array( $to ) )
-       	 $to = explode( ',', $to );
- 
- 		$to_addresses = [];
-
-	    foreach ( (array) $to as $recipient ) {
-	        
-	            // Break $recipient into name and address parts if in the format "Foo <bar@baz.com>"
-	            $recipient_name = '';
-	            if ( preg_match( '/(.*)<(.+)>/', $recipient, $matches ) ) {
-	                if ( count( $matches ) == 3 ) {
-	                    $recipient_name = $matches[1];
-	                    $recipient = $matches[2];
-	                }
-	            }
-
-	            $to_addresses[$recipient] = $recipient_name;
-
-	       
-	    }
-
-
-	    try{
-
-	    	$resp = $mg->send($from, $to_addresses, $subject, $message, $headers, $attachments);
-
-
-	    } catch (Exception $e){
-
-	    	$mail_error_data = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
- 
-	        /**
-	         * Fires after a phpmailerException is caught.
-	         *
-	         * @since 4.4.0
-	         *
-	         * @param WP_Error $error A WP_Error object with the phpmailerException code, message, and an array
-	         *                        containing the mail recipient, subject, message, headers, and attachments.
-	         */
-	        do_action( 'wp_mail_failed', new WP_Error( $e->getCode(), $e->getMessage(), $mail_error_data ) );
-	 
-	        return false;
-	    }
-
-	    return true;
-
-	}	
+	return true;
+}

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,17 @@
-=== WP Mail MailGun ===
+## WP Mail MailGun
+
 Contributors: stewarty, poweredbycoffee
 Donate link: http://poweredbycoffee.co.uk/
 Tags: wpmail mailgun transational-email
 Requires at least: 4.6
-Tested up to: 4.7
+Tested up to: 4.8
 Stable tag: 4.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Send Email from WordPress Via MailGun's transactional email service.
 
-== Description ==
+### Description
 
 Sometime you don't want to send email from your own webserver.  Some hosts don't allow it. It takes alot of resources and isn't alwats relaible.
 
@@ -22,25 +23,23 @@ This plugin will integrate MailGun with WordPress so it takes over sending all o
 
 Any mail sent via `wp_mail()` will be delivered via MailGun
 
+If no stable tag is provided, it is assumed that trunk is stable, but you should specify "trunk" if that's where you put the stable version, in order to eliminate any doubt.
 
+### Installation
 
-    If no stable tag is provided, it is assumed that trunk is stable, but you should specify "trunk" if that's where
-you put the stable version, in order to eliminate any doubt.
-
-== Installation ==
-
-e.g.
-1. Upload the plugin files to the `/wp-content/plugins/plugin-name` directory, or install the plugin through the WordPress plugins screen directly.
+1. Upload the plugin to the `wp-content/plugins` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress
 3. Sign up for a MailGun account - https://mailgun.com/signup
 4. Add your MailGun API Key and MailGun Domain to your wp-config.php as so
-	```define( 'MAILGUN_API_KEY', 'key-xxxxxxxxx');
-	 define( 'MAILGUN_DOMAIN', 'domain you set in MailGun');```
+    ```
+    define( 'MAILGUN_API_KEY', 'key-xxxxxxxxx');
+    define( 'MAILGUN_DOMAIN', 'your Mailgun domain');
+    ```
 5. Generate a few test emails in WordPress and you should see them in MailGun's Logs
 
 
 
-== Changelog ==
+### Changelog
 
 = 1.0 =
 Inital Launch


### PR DESCRIPTION
Hello! This plugin has just done me a huge favour, but I noticed an issue while setting it up.

Your new `wp_mail` function wasn't wrapped with a `function_exists` check, so it would cause Wordpress to complain when trying to enable the plugin.

This PR does the following
- standardises the whitespace (you had a mix of tabs/spaces!)
- wraps `wp_mail` in a `function_exists` check
- reformat the readme as Markdown

I've tested this on a Wordpress 4.8 install and it works fine, using it in combination with Gravity Forms with no problem.

Cheers!