### PR TITLE
Allow the 'from' name to be set

### DIFF
--- a/mailgun.php
+++ b/mailgun.php
@@ -54,7 +54,14 @@ class PBC_WP_Mail_MailGun {
 
 	public function send($from, $to, $subject, $message, $headers): void {
 		$builder = new \Mailgun\Message\MessageBuilder();
-		$builder->setFromAddress($from['address']);
+
+		if( isset( $from['name'] ) ) {
+			$name = array( 'first' => $from['name'] );
+		} else {
+			$name = array();
+		}
+
+		$builder->setFromAddress($from['address'], $name );
 
 		foreach($to as $email => $name) {
 			$builder->addToRecipient($email, [$name]);


### PR DESCRIPTION
Currently, there is no way of setting the _from_ name, as it is not included in the `setFromAddress` call. This prevents filters such as `wp_mail_from_name` from working as expected.